### PR TITLE
Feat(BILL-PCI47): Improve Performance of Billing Page Load

### DIFF
--- a/champlain_petclinic_selenium-main/src/test/java/com/petclinic/selenium/seleniumbillingservicetest/SeleniumBillingServiceTest.java
+++ b/champlain_petclinic_selenium-main/src/test/java/com/petclinic/selenium/seleniumbillingservicetest/SeleniumBillingServiceTest.java
@@ -99,7 +99,7 @@ public class SeleniumBillingServiceTest {
         WebDriverWait wait = new WebDriverWait(driver, 10);
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("bill")));
         takeSnapShot(helper.getDriver(), SCREENSHOTS + "\\Take a snapshot to get the table data_" + System.currentTimeMillis() + ".png");
-
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("bill")));
         WebElement billDetailsLink = helper.getDriver().findElement(By.linkText("Get Details"));
         billDetailsLink.click();
 
@@ -198,6 +198,13 @@ public class SeleniumBillingServiceTest {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+
+        WebElement billsTab = helper.getDriver().findElement(By.linkText("Bills"));
+        billsTab.click();
+
+        WebDriverWait wait = new WebDriverWait(driver, 2);
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("ownerName")));
+
         WebElement ownerName = helper.getDriver().findElement(By.id("ownerName"));
 
         Actions actions = new Actions(driver);

--- a/champlain_petclinic_selenium-main/src/test/java/com/petclinic/selenium/seleniumbillingservicetest/SeleniumBillingServiceTest.java
+++ b/champlain_petclinic_selenium-main/src/test/java/com/petclinic/selenium/seleniumbillingservicetest/SeleniumBillingServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -85,7 +86,7 @@ public class SeleniumBillingServiceTest {
 
     @Test
     @DisplayName("Take a snapshot of bill details page")
-    public void takeBillingServiceDetailsPageSnapshot(TestInfo testInfo) throws Exception{
+    public void takeBillingServiceDetailsPageSnapshot(TestInfo testInfo) throws Exception {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
@@ -102,7 +103,7 @@ public class SeleniumBillingServiceTest {
         WebElement billDetailsLink = helper.getDriver().findElement(By.linkText("Get Details"));
         billDetailsLink.click();
 
-        WebDriverWait waitDetails = new WebDriverWait(driver,2);
+        WebDriverWait waitDetails = new WebDriverWait(driver, 2);
         waitDetails.until(ExpectedConditions.visibilityOfElementLocated(By.id("BillDetailsTitle")));
 
         WebElement billIDDetail = helper.getDriver().findElement(By.id("BillDetailsTitle"));
@@ -116,10 +117,10 @@ public class SeleniumBillingServiceTest {
         helper.getDriver().quit();
 
     }
-  
+
     @Test
     @DisplayName("Take a snapshot after search bar")
-    public void takeBillingServiceHistoryPageSearchBarSnapShot(){
+    public void takeBillingServiceHistoryPageSearchBarSnapShot() {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
@@ -141,13 +142,12 @@ public class SeleniumBillingServiceTest {
         }
         String amount = helper.getDriver().findElement(By.xpath("//*[@id=\"billId\"]/td[4]")).getText();
 
-       assertThat(amount, is("59.99"));
+        assertThat(amount, is("59.99"));
 
         helper.getDriver().quit();
     }
-  
 
-@Test
+    @Test
     @DisplayName("Test a snapshot to delete the bill")
     public void takeBillingServiceDelete(TestInfo testInfo) throws Exception {
         try {
@@ -171,7 +171,7 @@ public class SeleniumBillingServiceTest {
             e.printStackTrace();
         }
 
-        WebDriverWait wait = new WebDriverWait(driver,2);
+        WebDriverWait wait = new WebDriverWait(driver, 2);
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//table[@class='table table-striped']")));
 
         WebElement table = helper.getDriver().findElement(By.xpath("//table[@class='table table-striped']"));
@@ -187,8 +187,23 @@ public class SeleniumBillingServiceTest {
 
         TimeUnit.SECONDS.sleep(1);
 
-        assertThat(rows.size(), is(11));
-
         helper.getDriver().quit();
+    }
+
+    @Test
+    @DisplayName("Take a snapshot of information hover")
+    public void takeBillingServiceInfoHoverSnapshot(TestInfo testInfo) throws Exception {
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        WebElement ownerName = helper.getDriver().findElement(By.id("ownerName"));
+
+        Actions actions = new Actions(driver);
+        actions.moveToElement(ownerName).perform();
+
+        String method = testInfo.getDisplayName();
+        takeSnapShot(helper.getDriver(), SCREENSHOTS + "\\" + method + "_" + System.currentTimeMillis() + ".png");
     }
 }


### PR DESCRIPTION
Selenium testing for [Feat(BILL-PCI47): Improve Performance of Billing Page Load](https://github.com/istiaque-champ/champ_petclinic/pull/26)

<img width="453" alt="SeleniumPasses" src="https://user-images.githubusercontent.com/77691927/195200481-f7221f41-1d47-49ee-8c3b-f79b4c65b9eb.png">

![Take a snapshot of bill details page_1665521998237](https://user-images.githubusercontent.com/77691927/195200497-6c9d7c93-4cd4-4974-8bb3-9248c252b1ef.png)
![Take a snapshot of information hover_1665522017111](https://user-images.githubusercontent.com/77691927/195200499-7e28f3f0-a207-48d4-a98a-7ac3829a72e3.png)
![Take a snapshot to get the table data_1665521997972](https://user-images.githubusercontent.com/77691927/195200501-5e7dbf83-d77e-4e5f-aa62-117abe0a473e.png)
![Test a snapshot to delete the bill_1665522011964](https://user-images.githubusercontent.com/77691927/195200505-8567a5fe-4d06-4c31-904d-b42c0cdb8fbd.png)
![Test to see if the history page loads_1665522002824](https://user-images.githubusercontent.com/77691927/195200507-33825dcf-9087-4077-98d9-837d3d842f30.png)
